### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/HamzaHassanM/laravel-social-auto-post/security/code-scanning/1](https://github.com/HamzaHassanM/laravel-social-auto-post/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/ci.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal safe setting is:

- `contents: read`

This is sufficient for `actions/checkout` and does not change intended functionality of build/test steps. No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
