### PR TITLE
feat: add legacy Laravel support (v8-v10) & secure CI workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2026-05-23
+
+### Added
+- **PHP Version Requirement**: Explicitly declared PHP requirement (`^8.1`) in `composer.json` to prevent installation on unsupported PHP versions (since enums require PHP 8.1+).
+- **Expanded Framework Compatibility**: Added full backward compatibility support for Laravel 8.x, 9.x, and 10.x. The package now supports Laravel 8.0 through 13.x.
+- **CI Workflow Hardening**: Merged security enhancement from PR #11, constraining GITHUB_TOKEN permissions to `contents: read` in GitHub Action workflows.
+
+### Fixed
+- **Localization Configuration Publishing**: Fixed incorrect service provider name (`SocialAutoPostServiceProvider` -> `SocialShareServiceProvider`) and tag name (`config` -> `autopost`) in French, Spanish, Turkish, and Chinese README files.
+
+### Changed
+- **Testing Suite Modernization**: Broadened Orchestra Testbench dev dependency (`^6.0` through `^11.0`) and PHPUnit dev dependency (`^9.5` through `^12.0`) to ensure development environment supports tests on older Laravel versions.
+
 ## [2.3.4] - 2026-05-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -54,34 +54,25 @@ A comprehensive Laravel package for automatic social media posting across **8 ma
 ### Requirements
 
 - PHP 8.1 or higher
-- Laravel 11.0 - 13.x
+- Laravel 8.0 - 13.x
 - Composer
 
 ### Laravel Version Compatibility
 
 | Package Version | Laravel Version | PHP Version | Status |
 |----------------|-----------------|-------------|--------|
-| 2.3.0          | Laravel 13.x    | PHP 8.2+    | Latest |
-| 2.2.1          | Laravel 13.x    | PHP 8.2+    | Supported |
-| 2.2.0          | Laravel 13.x    | PHP 8.2+    | Supported |
-| 2.1.0          | Laravel 12.x    | PHP 8.1+    | Supported |
-| 2.0.0          | Laravel 11.x    | PHP 8.1+    | Supported |
+| 2.4.x          | Laravel 8.x - 13.x | PHP 8.1+   | Latest |
+| 2.3.x          | Laravel 11.x - 13.x| PHP 8.2+   | Supported |
+| 2.2.x          | Laravel 13.x    | PHP 8.2+    | Supported |
+| 2.1.x          | Laravel 12.x    | PHP 8.1+    | Supported |
+| 2.0.x          | Laravel 11.x    | PHP 8.1+    | Supported |
 | 1.x            | Laravel 10.x    | PHP 8.0+    | Legacy |
 
 ### Install via Composer
 
 ```bash
-# Laravel 13.x (latest)
-composer require hamzahassanm/laravel-social-auto-post:^2.2
-
-# Laravel 12.x
-composer require hamzahassanm/laravel-social-auto-post:^2.1
-
-# Laravel 11.x
-composer require hamzahassanm/laravel-social-auto-post:^2.0
-
-# Laravel 10.x (Legacy)
-composer require hamzahassanm/laravel-social-auto-post:^1.0
+# Supports Laravel 8.x, 9.x, 10.x, 11.x, 12.x, and 13.x
+composer require hamzahassanm/laravel-social-auto-post
 ```
 
 ### Publish Configuration

--- a/README_ES.md
+++ b/README_ES.md
@@ -38,10 +38,10 @@ composer require hamzahassanm/laravel-social-auto-post
 Después de la instalación, publica el archivo de configuración:
 
 ```bash
-php artisan vendor:publish --provider="HamzaHassanM\LaravelSocialAutoPost\SocialAutoPostServiceProvider" --tag="config"
+php artisan vendor:publish --provider="HamzaHassanM\LaravelSocialAutoPost\SocialShareServiceProvider" --tag="autopost"
 ```
 
-Este comando creará un archivo `social-auto-post.php` en tu directorio `config`.
+Este comando creará un archivo `autopost.php` en tu directorio `config`.
 
 ## ⚙️ Configuración
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -38,10 +38,10 @@ composer require hamzahassanm/laravel-social-auto-post
 Après l'installation, publiez le fichier de configuration :
 
 ```bash
-php artisan vendor:publish --provider="HamzaHassanM\LaravelSocialAutoPost\SocialAutoPostServiceProvider" --tag="config"
+php artisan vendor:publish --provider="HamzaHassanM\LaravelSocialAutoPost\SocialShareServiceProvider" --tag="autopost"
 ```
 
-Cette commande créera un fichier `social-auto-post.php` dans votre répertoire `config`.
+Cette commande créera un fichier `autopost.php` dans votre répertoire `config`.
 
 ## ⚙️ Configuration
 

--- a/README_TR.md
+++ b/README_TR.md
@@ -38,10 +38,10 @@ composer require hamzahassanm/laravel-social-auto-post
 Kurulumdan sonra yapılandırma dosyasını yayınlayın:
 
 ```bash
-php artisan vendor:publish --provider="HamzaHassanM\LaravelSocialAutoPost\SocialAutoPostServiceProvider" --tag="config"
+php artisan vendor:publish --provider="HamzaHassanM\LaravelSocialAutoPost\SocialShareServiceProvider" --tag="autopost"
 ```
 
-Bu komut, `config` dizininize bir `social-auto-post.php` dosyası oluşturacaktır.
+Bu komut, `config` dizininize bir `autopost.php` dosyası oluşturacaktır.
 
 ## ⚙️ Yapılandırma
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -38,10 +38,10 @@ composer require hamzahassanm/laravel-social-auto-post
 安装完成后，发布配置文件：
 
 ```bash
-php artisan vendor:publish --provider="HamzaHassanM\LaravelSocialAutoPost\SocialAutoPostServiceProvider" --tag="config"
+php artisan vendor:publish --provider="HamzaHassanM\LaravelSocialAutoPost\SocialShareServiceProvider" --tag="autopost"
 ```
 
-该命令将在您的 `config` 目录中生成 `social-auto-post.php` 配置文件。
+该命令将在您的 `config` 目录中生成 `autopost.php` 配置文件。
 
 ## ⚙️ 配置
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,17 @@
+# Release Notes - v2.4.0
+
+## 📦 Backward Compatibility (Laravel 8.x - 10.x) & CI Hardening
+This release introduces extended support for legacy frameworks (Laravel 8.x, 9.x, and 10.x) while keeping full support for modern Laravel 11.x, 12.x, and 13.x projects.
+
+### 🌟 Key Changes
+- **Extended Laravel Support**: The package is now fully compatible with Laravel 8.0 through 13.x.
+- **PHP 8.1 Minimum Declared**: Explicitly restricted minimum PHP version to `^8.1` since the project uses PHP 8.1 enums. This prevents syntax/parse crashes in older PHP environments.
+- **CI Security Hardening (PR #11)**: Constrained the automatic `GITHUB_TOKEN` permissions in GitHub Action workflows to `contents: read` to protect against unauthorized modifications or tag injection.
+- **Localization fixes**: Fixed configuration publishing instructions across Spanish, French, Turkish, and Chinese READMEs (resolved wrong service provider and tag name references).
+- **Flexible Test Suite**: Broadened dev dependencies to support PHPUnit `^9.5` through `^12.0` and Orchestra Testbench `^6.0` through `^11.0` so development environments are stable on all PHP versions.
+
+---
+
 # Release Notes - v2.3.4
 
 ## 🚀 Extended Framework Support

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,12 @@
     "description": "Laravel social media auto post package - Complete solution for posting to 8 major social media platforms",
     "type": "library",
     "require": {
-        "laravel/framework": "^11.0|^12.0|^13.0"
+        "php": "^8.1",
+        "laravel/framework": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^12.0",
-        "orchestra/testbench": "^11.0"
+        "phpunit/phpunit": "^9.5|^10.0|^11.0|^12.0",
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0"
     },
     "license": "MIT",
     "autoload": {
@@ -23,7 +24,8 @@
     "authors": [
         {
             "name": "HamzaHassanM",
-            "email": "hamza.hassan.dev@gmail.com"
+            "email": "hamza.hassan.dev@gmail.com",
+            "role": "Developer"
         }
     ],
     "config": {


### PR DESCRIPTION
This PR adds full support for legacy Laravel versions (8.x, 9.x, and 10.x) while maintaining support for modern versions (11.x, 12.x, and 13.x).

It also defines a minimum PHP version requirement of `^8.1` to prevent parse errors on systems running older PHP versions (since enums are used).

Localization instructions in readmes (French, Spanish, Turkish, and Chinese) have also been corrected to point to the correct ServiceProvider and tag.