### PR TITLE
sec: resolve CVE-2025-27515 by raising Laravel framework lower bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2026-05-23
+
+### Fixed
+- **Security Vulnerability (CVE-2025-27515)**: Raised lower bounds of Laravel 10, 11, and 12 in `composer.json` (`^10.48.29`, `^11.44.1`, `^12.1.1`) to exclude versions vulnerable to the File Validation Bypass security advisory.
+
 ## [2.4.0] - 2026-05-23
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,17 @@
+# Release Notes - v2.4.1
+
+## 🔒 Security Fix: Laravel File Validation Bypass (CVE-2025-27515)
+This release updates the dependency requirements in `composer.json` to mitigate the security advisory CVE-2025-27515.
+
+### 🌟 Key Changes
+- **Dependency Raising**: Excluded vulnerable Laravel framework versions by raising the minimum bounds for supported major versions:
+  - Laravel 10.x requirement raised from `^10.0` to `^10.48.29`.
+  - Laravel 11.x requirement raised from `^11.0` to `^11.44.1`.
+  - Laravel 12.x requirement raised from `^12.0` to `^12.1.1`.
+- **Preserved Compatibility**: Legacy EOL versions (Laravel 8 and 9) and the latest Laravel 13 remain unaffected by these lower bound updates.
+
+---
+
 # Release Notes - v2.4.0
 
 ## 📦 Backward Compatibility (Laravel 8.x - 10.x) & CI Hardening

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^8.1",
-        "laravel/framework": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
+        "laravel/framework": "^8.0|^9.0|^10.48.29|^11.44.1|^12.1.1|^13.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5|^10.0|^11.0|^12.0",
@@ -27,6 +27,20 @@
             "email": "hamza.hassan.dev@gmail.com",
             "role": "Developer"
         }
+    ],
+    "keywords": [
+        "laravel",
+        "social media",
+        "auto post",
+        "facebook",
+        "twitter",
+        "linkedin",
+        "instagram",
+        "tiktok",
+        "youtube",
+        "pinterest",
+        "telegram",
+        "PHP"
     ],
     "config": {
         "sort-packages": true


### PR DESCRIPTION
This PR updates composer.json dependency requirements for laravel/framework to mitigate CVE-2025-27515 (File Validation Bypass).

It raises the lower bound for:
- Laravel 10.x to ^10.48.29
- Laravel 11.x to ^11.44.1
- Laravel 12.x to ^12.1.1