### PR TITLE
fix: use double pipes in composer constraints for Renovate compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "type": "library",
     "require": {
         "php": "^8.1",
-        "laravel/framework": "^8.0|^9.0|^10.48.29|^11.44.1|^12.1.1|^13.0"
+        "laravel/framework": "^8.0 || ^9.0 || ^10.48.29 || ^11.44.1 || ^12.1.1 || ^13.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5|^10.0|^11.0|^12.0",
-        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0"
+        "phpunit/phpunit": "^9.5 || ^10.0 || ^11.0 || ^12.0",
+        "orchestra/testbench": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0"
     },
     "license": "MIT",
     "autoload": {


### PR DESCRIPTION
Replaces single pipes with double pipes to resolve Renovate's Unsupported composer value warning.